### PR TITLE
docker 向けに Wget でのアクセスラッパーに置き換え

### DIFF
--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -801,7 +801,7 @@ class Downloader
       "subtitles" => subtitles
     }
     toc_objects
-  rescue OpenURI::HTTPError, Errno::ECONNRESET, Errno::ETIMEDOUT, Net::OpenTimeout, IO::TimeoutError => e
+  rescue OpenURI::HTTPError, Errno::ECONNRESET => e
     raise if through_error   # エラー処理はしなくていいからそのまま例外を受け取りたい時用
     if e.message.include?("404")
       @stream.error "小説が削除されているか非公開な可能性があります"
@@ -1174,7 +1174,7 @@ class Downloader
       URI.open(url, "r:#{@setting["encoding"]}", open_uri_options) do |fp|
         raw = Helper.pretreatment_source(fp.read, @setting["encoding"])
       end
-    rescue OpenURI::HTTPError, Errno::ECONNRESET, Errno::ETIMEDOUT, Net::OpenTimeout, IO::TimeoutError => e
+    rescue OpenURI::HTTPError, Errno::ECONNRESET => e
       case e.message
       when /^503/
         # 503 はアクセス規制やメンテ等でリトライしてもほぼ意味がないことが多いため一度で諦める

--- a/lib/extension.rb
+++ b/lib/extension.rb
@@ -4,18 +4,19 @@
 # Copyright 2013 whiteleaf. All rights reserved.
 #
 
-require "open-uri"
-require "openssl"
-require_relative "inventory"
-
-# open-uri で http → https へのリダイレクトを有効にする
-require "open_uri_redirections"
+require_relative "wget"
 
 # open-uri に渡すオプションを生成（必要に応じて extensions/*.rb でオーバーライドする）
 def make_open_uri_options(add)
-  ua = Inventory.load("local_setting")["user-agent"] || "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
-  add.merge(ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE)
-  add.merge("User-Agent" => ua)
+  # This is now handled by the wget wrapper, but we keep the method for compatibility.
+  add
+end
+
+module OpenURI
+  def self.open_uri(name, *rest, &block)
+    # Forward to our wget wrapper
+    Narou::Wget.open(name, *rest, &block)
+  end
 end
 
 #

--- a/lib/illustration.rb
+++ b/lib/illustration.rb
@@ -4,7 +4,7 @@
 # Copyright 2013 whiteleaf. All rights reserved.
 #
 
-require "open-uri"
+require_relative "wget"
 
 #
 # 挿絵管理

--- a/lib/narou/api.rb
+++ b/lib/narou/api.rb
@@ -4,7 +4,7 @@
 # Copyright 2013 whiteleaf. All rights reserved.
 #
 
-require "open-uri"
+require_relative "../wget"
 require "zlib"
 require "yaml"
 require "json"

--- a/lib/novelinfo.rb
+++ b/lib/novelinfo.rb
@@ -4,7 +4,7 @@
 # Copyright 2013 whiteleaf. All rights reserved.
 #
 
-require "open-uri"
+require_relative "wget"
 require "time"
 require_relative "html"
 

--- a/lib/wget.rb
+++ b/lib/wget.rb
@@ -3,11 +3,10 @@
 require "stringio"
 require "open-uri" # For OpenURI::HTTPError
 require "systemu"
+require_relative "inventory"
 
 module Narou
   module Wget
-    USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0"
-
     # A StringIO-like object that mimics the object returned by open-uri.
     class WgetIO < StringIO
       attr_reader :meta, :status
@@ -29,13 +28,16 @@ module Narou
     def self.open(uri, *rest, &block)
       options = rest.find { |arg| arg.is_a?(Hash) } || {}
 
+      ua = Inventory.load("local_setting")["user-agent"] || "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0"
+
       # Build wget command
       cmd_headers = []
       # Default headers from user's prompt
-      cmd_headers << %'--header="User-Agent: #{USER_AGENT}"'
+      cmd_headers << %'--header="User-Agent: #{ua}"'
       cmd_headers << %'--header="Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"'
       cmd_headers << %'--header="Accept-Language: en-US,en;q=0.5"'
       cmd_headers << %'--header="Accept-Encoding: gzip, deflate"'
+      cmd_headers << %'--header="Accept-Charset: utf-8"'
       cmd_headers << %'--header="Connection: keep-alive"'
 
       # Headers from options hash

--- a/lib/wget.rb
+++ b/lib/wget.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "stringio"
+require "open-uri" # For OpenURI::HTTPError
+require "systemu"
+
+module Narou
+  module Wget
+    USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0"
+
+    # A StringIO-like object that mimics the object returned by open-uri.
+    class WgetIO < StringIO
+      attr_reader :meta, :status
+
+      def initialize(initial_string = "", meta = {}, status = [])
+        super(initial_string)
+        @meta = meta
+        @status = status
+      end
+
+      def base_uri
+        # This is a simplification. Real redirection handling is more complex.
+        # wget follows redirections by default. The last Location is what we want.
+        # But parsing it from stderr is tricky. Let's just return the original uri.
+        @meta["uri"]
+      end
+    end
+
+    def self.open(uri, *rest, &block)
+      options = rest.find { |arg| arg.is_a?(Hash) } || {}
+
+      # Build wget command
+      cmd_headers = []
+      # Default headers from user's prompt
+      cmd_headers << %'--header="User-Agent: #{USER_AGENT}"'
+      cmd_headers << %'--header="Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"'
+      cmd_headers << %'--header="Accept-Language: en-US,en;q=0.5"'
+      cmd_headers << %'--header="Accept-Encoding: gzip, deflate"'
+      cmd_headers << %'--header="Connection: keep-alive"'
+
+      # Headers from options hash
+      options.each do |key, value|
+        next unless key.is_a?(String)
+        cmd_headers << %'--header="#{key}: #{value}"'
+      end
+
+      command = %'wget --server-response --compression=auto -O - #{cmd_headers.join(" ")} "#{uri}"'
+
+      status, stdout, stderr = systemu(command)
+
+      unless status.success?
+        if stderr =~ /(\d{3}) (Not Found|Forbidden|Error)/
+          raise OpenURI::HTTPError.new("#{status.exitstatus} #{$2}", nil)
+        else
+          raise OpenURI::HTTPError.new("wget command failed: #{stderr.strip}", nil)
+        end
+      end
+
+      # Parse headers from stderr
+      response_headers = {}
+      status_line = []
+      # The last header block in stderr is the one for the final response
+      last_header_block = stderr.split(/(\r\n\r\n|\n\n)/).select{|s| s.start_with?("  HTTP/")}.last || ""
+      last_header_block.each_line do |line|
+        if line.strip.start_with?("HTTP/")
+          _http, code, msg = line.strip.split(" ", 3)
+          status_line = [code, msg]
+        elsif line =~ /^\s*([^:]+):\s*(.+)$/
+          response_headers[$1.downcase] = $2.strip
+        end
+      end
+
+      io = WgetIO.new(stdout, response_headers, status_line)
+      io.meta["uri"] = uri # Store original URI
+
+      if block_given?
+        begin
+          yield io
+        ensure
+          # StringIO doesn't need closing, but for compatibility.
+        end
+      else
+        return io
+      end
+    end
+  end
+end

--- a/narou.gemspec
+++ b/narou.gemspec
@@ -60,7 +60,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'memoist', '~> 0.11.0'
   gem.add_runtime_dependency 'systemu', '~> 2.6', '>= 2.6.5'
   gem.add_runtime_dependency 'erubi', '~> 1.13'
-  gem.add_runtime_dependency 'open_uri_redirections', '~> 0.2', '>= 0.2.1'
   gem.add_runtime_dependency 'activesupport', '>= 6.1', '< 8.0'
   gem.add_runtime_dependency 'unicode-display_width', '~> 1.4'
   gem.add_runtime_dependency 'webrick', '~> 1.7'


### PR DESCRIPTION
Linux 上だと UA を指定してもハーメルンがDLできなかった。
しかし、Wget ベースに変えるとアクセスできることが判明。

Wget ベースのラッパーに処理を置き換え