### PR TITLE
無駄に NTP に対応

### DIFF
--- a/lib/command/update/scheduler.rb
+++ b/lib/command/update/scheduler.rb
@@ -71,7 +71,7 @@ module Command
             ntp_time = Net::NTP.get(server).time
             @ntp_cache = ntp_time
             @ntp_cache_time = Time.now
-            puts "NTP時刻を取得しました (#{server}): #{ntp_time.strftime('%Y/%m/%d %H:%M:%S')}"
+            puts "NTP時刻を取得しました (#{server}) 最終取得時間: #{ntp_time.strftime('%Y/%m/%d %H:%M:%S')}"
             return ntp_time
           rescue => e
             puts "NTPサーバー #{server} への接続に失敗しました: #{e.message}"
@@ -149,7 +149,7 @@ module Command
 
       def execute_auto_update
         ntp_time = get_ntp_time
-        puts "自動アップデートを実行中... (#{ntp_time.strftime('%Y/%m/%d %H:%M:%S')} NTP)"
+        puts "自動アップデートを実行中... (#{ntp_time.strftime('%Y/%m/%d %H:%M:%S')} 正確な時刻)"
         
         begin
           # WebWorkerを使用して非同期実行

--- a/lib/command/update/scheduler.rb
+++ b/lib/command/update/scheduler.rb
@@ -1,5 +1,6 @@
 require "time"
 require "thread"
+require "net/ntp"
 require_relative "../../inventory"
 
 module Command
@@ -9,6 +10,10 @@ module Command
         @thread = nil
         @running = false
         @mutex = Mutex.new
+        @ntp_servers = ["ntp.nict.jp", "ntp.tohoku.ac.jp", "time.google.com", "pool.ntp.org"]
+        @ntp_cache = nil
+        @ntp_cache_time = nil
+        @ntp_cache_duration = 3600 # 1時間キャッシュ
       end
 
       def start
@@ -52,6 +57,33 @@ module Command
 
       private
 
+      def get_ntp_time
+        # キャッシュが有効な場合は使用
+        if @ntp_cache && @ntp_cache_time && 
+           (Time.now - @ntp_cache_time) < @ntp_cache_duration
+          offset = Time.now - @ntp_cache_time
+          return @ntp_cache + offset
+        end
+
+        # NTPサーバーから時刻を取得
+        @ntp_servers.each do |server|
+          begin
+            ntp_time = Net::NTP.get(server).time
+            @ntp_cache = ntp_time
+            @ntp_cache_time = Time.now
+            puts "NTP時刻を取得しました (#{server}): #{ntp_time.strftime('%Y/%m/%d %H:%M:%S')}"
+            return ntp_time
+          rescue => e
+            puts "NTPサーバー #{server} への接続に失敗しました: #{e.message}"
+            next
+          end
+        end
+        
+        # 全てのNTPサーバーで失敗した場合はローカル時刻を使用
+        puts "全てのNTPサーバーへの接続に失敗しました。ローカル時刻を使用します。"
+        Time.now
+      end
+
       def run_scheduler(schedule_string)
         while @running
           times = parse_schedule_times(schedule_string)
@@ -88,8 +120,8 @@ module Command
       def calculate_next_run_time(times)
         return nil if times.empty?
         
-        now = Time.now
-        today = Date.today
+        now = get_ntp_time
+        today = now.to_date
         
         # 今日の時間をチェック
         times.each do |time|
@@ -105,7 +137,7 @@ module Command
 
       def sleep_until(target_time)
         while @running
-          now = Time.now
+          now = get_ntp_time
           if now >= target_time
             break
           end
@@ -116,7 +148,8 @@ module Command
       end
 
       def execute_auto_update
-        puts "自動アップデートを実行中... (#{Time.now.strftime('%Y/%m/%d %H:%M:%S')})"
+        ntp_time = get_ntp_time
+        puts "自動アップデートを実行中... (#{ntp_time.strftime('%Y/%m/%d %H:%M:%S')} NTP)"
         
         begin
           # WebWorkerを使用して非同期実行

--- a/narou.gemspec
+++ b/narou.gemspec
@@ -67,6 +67,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'psych', '~> 4.0'
   gem.add_runtime_dependency 'nkf', '~> 0.2.0'
   gem.add_runtime_dependency 'csv', '~> 3.0.0'
+  gem.add_runtime_dependency 'net-ntp', '~> 2.1', '>= 2.1.3'
 
   gem.add_development_dependency 'rspec', '~> 3.10'
   gem.add_development_dependency 'rspec-retry', '~> 0.6'


### PR DESCRIPTION
自動更新を目指すから一葉ね...?

ntp.nict.jp
ntp.tohoku.ac.jp
time.google.com
pool.ntp.org

を一応候補に