### PR TITLE
CUIでのnarou convert実行時における不定期なIOError修正案

### DIFF
--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -582,8 +582,12 @@ module Helper
 
         # Output reading threads
         out_t = Thread.new { stdout.read }
+	# Wait child process finish
+	out_t.join
+	stdout.close
         err_t = Thread.new { stderr.read }
-
+	err_t.join
+	stderr.close
         # Monitoring loop
         loop do
           # Check if process finished

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -582,12 +582,12 @@ module Helper
 
         # Output reading threads
         out_t = Thread.new { stdout.read }
-	# Wait child process finish
-	out_t.join
-	stdout.close
+        # Wait child process finish
+        out_t.join
+        stdout.close
         err_t = Thread.new { stderr.read }
-	err_t.join
-	stderr.close
+        err_t.join
+        stderr.close
         # Monitoring loop
         loop do
           # Check if process finished


### PR DESCRIPTION

いつも大変お世話になっております。好きな作品を手元に置けて、タグによる管理が便利でとても助かっています。

以前まで正常に変換できていたのですが、改めてgem全体を削除してアップデートした所、
正常に変換できる作品と変換できない作品が出てきたため報告致します。

「ruby 'IO#read': stream closed in another thread err_t = Thread.new { stderr.read }」
でGeminiに聞いた所、一番非破壊かなと思われる2を試し、無事変換できたので報告致します。

おま環の可能性もあるので棄却も考慮の程、よろしくお願いします。

# 環境
```bash
$ gem -v
4.0.3
$ ruby -v
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +PRISM [x86_64-linux]
$ uname -a
Linux narou 6.17.9-1-pve #1 SMP PREEMPT_DYNAMIC PMX 6.17.9-1 (2026-01-12T16:25Z) x86_64 x86_64 x86_64 GNU/Linux
(Proxmox9 + )
```
# Geminiの提案
解決策
このエラーを回避するための一般的なアプローチは以下の通りです。
1. Open3 ライブラリを使用する（推奨）
標準ライブラリのOpen3を使用すると、スレッド管理を安全に行えます。Open3.capture3やOpen3.popen3は、各ストリームを正しく読み込み、クローズ処理を適切に管理します。 
```ruby
ruby
require 'open3'

## popen3 を使用して安全に読み込む
stdout_str, stderr_str, status = Open3.capture3("your_command")
## stderr_str に内容が入っている
```
https://stackoverflow.com/questions/13639515/how-do-i-get-both-stdout-and-stderr-separately-from-a-process-call-in-ruby#:~:text=48-,Related,streaming%20stdout%20&%20stderr%20in%20Ruby

2. ensureブロックで読み込みを完了させる
コマンドの終了後にstderr.readを行うのではなく、プロセスが生きている間に読み込みを完結させ、パイプのクローズはスレッドの読み込みが終わった後に実行します。 
```ruby
# エラーになりやすい例
# err_t = Thread.new { stderr.read }
# ... ここでメインスレッドがclose ...

# 改善例
thr = Thread.new { stderr.read }
# 子プロセスの終了待ちなどをする
thr.join
stderr.close
```
3. エラーを無視する（rescue）
stream closed例外は、すでにクローズされているIOに対して再度クローズを行おうとした際にも発生します。もしストリームが閉じていることが想定内であれば、エラーをrescueして無視します。 
()[https://bugs.ruby-lang.org/issues/14681]
```ruby
err_t = Thread.new do
  begin
    stderr.read
  rescue IOError
    # ストリームが既にクローズされている場合は無視
    ""
  end
end
```
https://www.ruby-forum.com/t/stream-closed-ioerror/150169

# エラーログ
```bash
$ narou convert 4
>> EPUB用に変換します
変換処理開始: 1件の小説を処理します
[1/1] 処理中: 4
ID:4　＜Infinite Dendrogram＞-インフィニット・デンドログラム- の変換を開始
縦書用の変換が終了しました
AozoraEpub3でEPUBに変換しています.[1/1] 完了: 4                                               変換中:1
#<Thread:0x00007159b4ee1928 /root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/narou-3.9.1.mod.R1.5/lib/helper.rb:584 run> terminated with exception (report_on_exception is true):
/root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/narou-3.9.1.mod.R1.5/lib/helper.rb:584:in 'IO#read': stream closed in another thread (IOError)
        from /root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/narou-3.9.1.mod.R1.5/lib/helper.rb:584:in 'block (2 levels) in Helper::AsyncCommand.exec'
/root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/narou-3.9.1.mod.R1.5/lib/helper.rb:584:in 'IO#read': stream closed in another thread (IOError)
        from /root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/narou-3.9.1.mod.R1.5/lib/helper.rb:584:in 'block (2 levels) in Helper::AsyncCommand.exec'
/root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/narou-3.9.1.mod.R1.5/narou.rb:45:in 'Kernel#exit': exit (SystemExit)
        from /root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/narou-3.9.1.mod.R1.5/narou.rb:45:in '<main>'
        from /root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/narou-3.9.1.mod.R1.5/bin/narou:54:in 'Kernel#require_relative'
        from /root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/narou-3.9.1.mod.R1.5/bin/narou:54:in '<top (required)>'
        from /root/.rbenv/versions/3.4.2/lib/ruby/site_ruby/3.4.0/rubygems.rb:303:in 'Kernel#load'
        from /root/.rbenv/versions/3.4.2/lib/ruby/site_ruby/3.4.0/rubygems.rb:303:in 'Gem.activate_and_load_bin_path'
        from /root/.rbenv/versions/3.4.2/bin/narou:25:in '<main>'
#<Thread:0x00007159b4ee1798 /root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/narou-3.9.1.mod.R1.5/lib/helper.rb:585 run> terminated with exception (report_on_exception is true):
/root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/narou-3.9.1.mod.R1.5/lib/helper.rb:585:in 'IO#read': stream closed in another thread (IOError)
        from /root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/narou-3.9.1.mod.R1.5/lib/helper.rb:585:in 'block (2 levels) in Helper::AsyncCommand.exec'
```